### PR TITLE
Add changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
       - name: gh release create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ github.event.inputs.tag }} dist/*
+        run: gh release create ${{ github.event.inputs.tag }} -F CHANGELOG.md dist/*
 
   publish:
     needs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,30 +51,32 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Get semver release version
+        id: semver
+        run: echo "SEMVER=$(sed 's/-.*//' <<< ${{ github.event.inputs.tag }})" >> $GITHUB_ENV
       - name: gh release create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://github.com/cli/cli/issues/2067#issuecomment-704224994
         run: |
-          title=$(sed 's/-.*//' <<< ${{ github.event.inputs.tag }})
-          sed -n '/^## $title/,/^## /p' CHANGELOG.md | sed '1d;$d' | \
+          sed -n '/^## ${{ env.SEMVER }}/,/^## /p' CHANGELOG.md | sed '1d;$d' | \
           gh release create ${{ github.event.inputs.tag }} \
             -t ${{ github.event.inputs.tag }} \
             -F - \
             dist/*
 
-  publish:
-    needs:
-      - build
-      - release
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+  # publish:
+  #   needs:
+  #     - build
+  #     - release
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: dist
+  #         path: dist
+  #     - name: Publish to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,7 @@ jobs:
       - name: gh release create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://github.com/cli/cli/issues/2067#issuecomment-704224994
         run: |
           sed -n '/^## ${{ github.event.inputs.tag }}/,/^## /p' CHANGELOG.md | sed '1d;$d' | \
           gh release create ${{ github.event.inputs.tag }}-rc2 \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,12 @@ jobs:
       - name: gh release create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ github.event.inputs.tag }} -F CHANGELOG.md dist/*
+        run: |
+          sed -n '/^## ${{ github.event.inputs.tag }}/,/^## /p' CHANGELOG.md | sed '1d;$d' | \
+          gh release create ${{ github.event.inputs.tag }}-rc2 \
+            -t ${{ github.event.inputs.tag }}-rc2 \
+            -F - \
+            dist/*
 
   publish:
     needs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,18 +65,18 @@ jobs:
             -F - \
             dist/*
 
-  # publish:
-  #   needs:
-  #     - build
-  #     - release
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #   steps:
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: dist
-  #         path: dist
-  #     - name: Publish to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+  publish:
+    needs:
+      - build
+      - release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,9 +56,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://github.com/cli/cli/issues/2067#issuecomment-704224994
         run: |
-          sed -n '/^## ${{ github.event.inputs.tag }}/,/^## /p' CHANGELOG.md | sed '1d;$d' | \
-          gh release create ${{ github.event.inputs.tag }}-rc2 \
-            -t ${{ github.event.inputs.tag }}-rc2 \
+          title=$(sed 's/-.*//' <<< ${{ github.event.inputs.tag }})
+          sed -n '/^## $title/,/^## /p' CHANGELOG.md | sed '1d;$d' | \
+          gh release create ${{ github.event.inputs.tag }} \
+            -t ${{ github.event.inputs.tag }} \
             -F - \
             dist/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is the first release which uses the `CHANGELOG` file.
 - Widen support from just Python 3.11 to Python 3.9, 3.10, 3.11, and 3.12 ([#3](https://github.com/sebpretzer/rst-in-md/pull/3))
 - Add support for SuperFences ([#4](https://github.com/sebpretzer/rst-in-md/pull/4))
 - Auto-Configure SuperFence custom fences ([#5](https://github.com/sebpretzer/rst-in-md/pull/5))
+- Add a changelog ([#6](https://github.com/sebpretzer/rst-in-md/pull/6))
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This is the first release which uses the `CHANGELOG` file.
 - Widen support from just Python 3.11 to Python 3.9, 3.10, 3.11, and 3.12 ([#3](https://github.com/sebpretzer/rst-in-md/pull/3))
 - Add support for SuperFences ([#4](https://github.com/sebpretzer/rst-in-md/pull/4))
 - Auto-Configure SuperFence custom fences ([#5](https://github.com/sebpretzer/rst-in-md/pull/5))
-- Add a changelog ([#6](https://github.com/sebpretzer/rst-in-md/pull/6))
+- Add support for a changelog ([#6](https://github.com/sebpretzer/rst-in-md/pull/6))
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.2.0
+
+This is the first release which uses the `CHANGELOG` file.
+
+- Widen support from just Python 3.11 to Python 3.9, 3.10, 3.11, and 3.12 ([#3](https://github.com/sebpretzer/rst-in-md/pull/3))
+- Add support for SuperFences ([#4](https://github.com/sebpretzer/rst-in-md/pull/4))
+- Auto-Configure SuperFence custom fences ([#5](https://github.com/sebpretzer/rst-in-md/pull/5))
+
+## 0.1.0
+
+- Initial release
+- Support for Python 3.11


### PR DESCRIPTION
Goals:
1. Add a changelog
2. Integrate changelog into releases and CI
    1. Parse the changelog and only release relevant info, instead of the entire changelog (see https://github.com/cli/cli/issues/2067#issuecomment-704224994 for more info)
    2. When publishing a release candidate, it the root semver version still needs to be found from the changelog: the release is `0.2.0-rc1` but the changelog still only has `0.2.0`