### PR TITLE
No auto configurator

### DIFF
--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -22,3 +22,30 @@ markdown_extensions:
 ```
 
 You can read more about this integration in the [explanation](../explanations/implementation.md#integration-with-pymdown-extensions-superfences) and [reference](../reference/superfence.md#superfence).
+
+!!! warning "Auto-Configuration"
+    By installing both `rst-in-md` and `pymdownx.superfences`, you invoke an [auto-configurator](../reference/superfence.md#rst_in_md.RestructuredTextInMarkdownAutoConfigurator) that will remove `rst-in-md` and add the proper custom fences for `pymdownx.superfences`. It is equivalent to the following configuration:
+
+    ```diff
+    markdown_extensions:
+      - attr_list
+    - - rst_in_md
+      - pymdownx.superfences:
+    +     custom_fences:
+    +       - name: rst
+    +         class: rst-in-md
+    +         format: !!python/name:rst_in_md.superfence_formatter
+    +        validate: !!python/name:rst_in_md.superfence_validator
+    +       - name: rest
+    +         class: rst-in-md
+    +         format: !!python/name:rst_in_md.superfence_formatter
+    +         validate: !!python/name:rst_in_md.superfence_validator
+    +       - name: restructuredtext
+    +         class: rst-in-md
+    +         format: !!python/name:rst_in_md.superfence_formatter
+    +         validate: !!python/name:rst_in_md.superfence_validator
+    ```
+
+    If you want to customize the `custom_fences`, you can do so by simply not including `rst-in-md` in the `markdown_extensions` and specifying the `custom_fences` yourself.
+
+    _The auto-configurator will work with [other custom fences like `mermaid.js`](https://facelessuser.github.io/pymdown-extensions/extras/mermaid/#using-in-mkdocs) as well, so only do this if you want to customize the `rst-in-md` superfences in particular._

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -24,7 +24,7 @@ markdown_extensions:
 You can read more about this integration in the [explanation](../explanations/implementation.md#integration-with-pymdown-extensions-superfences) and [reference](../reference/superfence.md#superfence).
 
 !!! warning "Auto-Configuration"
-    By installing both `rst-in-md` and `pymdownx.superfences`, you invoke an [auto-configurator](../reference/superfence.md#rst_in_md.RestructuredTextInMarkdownAutoConfigurator) that will remove `rst-in-md` and add the proper custom fences for `pymdownx.superfences`. It is equivalent to the following configuration:
+    By installing both `rst-in-md` and `pymdownx.superfences`, you invoke an [auto-configurator](../reference/superfence.md#rst_in_md.RestructuredTextInMarkdownAutoConfigurator) that will remove `rst-in-md` and add the proper `custom_fences` for `pymdownx.superfences`. It is equivalent to the following configuration:
 
     ```diff
     markdown_extensions:

--- a/rst_in_md/__init__.py
+++ b/rst_in_md/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
 __version__ = "0.0.0"
 
 
-def makeExtension(**kwargs) -> Extension:  # noqa: N802, ANN003
+def makeExtension(**kwargs: dict) -> Extension:  # noqa: N802
     """Return an instance of the RestructuredTextInMarkdown extension.
 
     This function is specified by the markdown package, so that it can properly load the

--- a/rst_in_md/superfence.py
+++ b/rst_in_md/superfence.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-def superfence_formatter(
+def superfence_formatter(  # noqa: D417
     source: str,
     language: str,  # noqa: ARG001
     css_class: str,  # noqa: ARG001
@@ -36,7 +36,6 @@ def superfence_formatter(
         css_class (str): CSS class of the superfence _(required, but not used)_.
         options (dict): Options of the superfence _(required, but not used)_.
         md (Markdown): The markdown instance _(required, but not used)_.
-        **kwargs (dict): Additional arguments _(required, but not used)_.
 
     Returns:
         str: The converted html.

--- a/tests/compatibility/test_superfences.py
+++ b/tests/compatibility/test_superfences.py
@@ -21,7 +21,7 @@ def md():
     )
 
 
-def test_no_auto_configurator_without_pymdownx():
+def test_auto_configurator_installed_properly():
     # https://stackoverflow.com/a/65034142
     with patch.dict(sys.modules, {k: None for k in sys.modules if "pymdownx" in k}):
         md = Markdown(
@@ -31,12 +31,24 @@ def test_no_auto_configurator_without_pymdownx():
                 "fenced_code",
             ],
         )
+        assert "rst-in-md" in md.preprocessors
         assert "rst-in-md-auto-configurator" not in md.preprocessors
+
+    md = Markdown(
+        extensions=[
+            "attr_list",
+            "fenced_code",
+            "pymdownx.superfences",
+        ],
+    )
+    assert "rst-in-md" not in md.preprocessors
+    assert "rst-in-md-auto-configurator" not in md.preprocessors
 
 
 def test_load_extension_with_pymdownx(md):
+    assert "rst-in-md" in md.preprocessors
+    assert "rst-in-md-auto-configurator" in md.preprocessors
     assert md.preprocessors.get_index_for_name("rst-in-md-auto-configurator") == 0
-    assert md.preprocessors["rst-in-md"]
 
     assert md.preprocessors["fenced_code_block"].config.get("custom_fences", []) == []
 
@@ -77,12 +89,13 @@ def test_load_extension_without_pymdownx(md):
         ],
     )
 
+    assert "rst-in-md" in md.preprocessors
+    assert "rst-in-md-auto-configurator" in md.preprocessors
     assert md.preprocessors.get_index_for_name("rst-in-md-auto-configurator") == 0
-    assert md.preprocessors["rst-in-md"]
 
     md.convert(source="placeholder")
 
-    assert md.preprocessors["rst-in-md"]
+    assert "rst-in-md" in md.preprocessors
 
 
 def test_superfence_inside_admonition(md):


### PR DESCRIPTION
This PR replaces https://github.com/sebpretzer/rst-in-md/pull/10. We don't need fancy logic to not install the auto-configurator, we just need to not include `rst_in_md` in the markdown extensions